### PR TITLE
Reduced verbosity of some very common log messages from DEBUG to TRACE

### DIFF
--- a/src/enml/ENMLConverter_p.cpp
+++ b/src/enml/ENMLConverter_p.cpp
@@ -1335,7 +1335,7 @@ bool ENMLConverterPrivate::validateAndFixupEnml(QString & enml, ErrorString & er
 bool ENMLConverterPrivate::noteContentToPlainText(const QString & noteContent, QString & plainText,
                                                   ErrorString & errorMessage)
 {
-    QNDEBUG(QStringLiteral("ENMLConverterPrivate::noteContentToPlainText: ") << noteContent);
+    QNTRACE(QStringLiteral("ENMLConverterPrivate::noteContentToPlainText: ") << noteContent);
 
     plainText.resize(0);
 

--- a/src/local_storage/LocalStorageCacheManager_p.cpp
+++ b/src/local_storage/LocalStorageCacheManager_p.cpp
@@ -88,7 +88,8 @@ void LocalStorageCacheManagerPrivate::cache##Type(const Type & name) \
             res = m_cacheExpiryChecker->expiry_checker(); \
             if (Q_UNLIKELY(!res)) { \
                 auto latIndexBegin = latIndex.begin(); \
-                QNDEBUG(QStringLiteral("Going to remove the object from local storage cache: ") << *latIndexBegin); \
+                QNDEBUG(QStringLiteral("Going to remove the object from local storage cache")); \
+                QNTRACE(QStringLiteral("Content: ") << *latIndexBegin); \
                 Q_UNUSED(latIndex.erase(latIndexBegin)); \
                 continue; \
             } \
@@ -118,7 +119,8 @@ void LocalStorageCacheManagerPrivate::cache##Type(const Type & name) \
         throw LocalStorageCacheManagerException(error); \
     } \
     \
-    QNDEBUG(QStringLiteral("Added " #name " to the local storage cache: ") << name); \
+    QNDEBUG(QStringLiteral("Added " #name " to the local storage cache")); \
+    QNTRACE(QStringLiteral("Content: ") << name); \
 }
 
 CACHE_OBJECT(Note, note, NotesCache, m_notesCache, checkNotes, ByLocalUid, localUid)

--- a/src/local_storage/LocalStorageManager_p.cpp
+++ b/src/local_storage/LocalStorageManager_p.cpp
@@ -3266,7 +3266,7 @@ int LocalStorageManagerPrivate::enResourceCount(ErrorString & errorDescription) 
 bool LocalStorageManagerPrivate::findEnResource(Resource & resource, ErrorString & errorDescription,
                                                 const bool withBinaryData) const
 {
-    QNDEBUG(QStringLiteral("LocalStorageManagerPrivate::findEnResource: ") << resource);
+    QNTRACE(QStringLiteral("LocalStorageManagerPrivate::findEnResource: ") << resource);
 
     ErrorString errorPrefix(QT_TR_NOOP("Can't find resource in the local storage database"));
 
@@ -9049,7 +9049,7 @@ bool LocalStorageManagerPrivate::findAndSetTagIdsPerNote(Note & note, ErrorStrin
             return false;
         }
 
-        QNDEBUG(QStringLiteral("Found tag local uid ") << tagLocalUid << QStringLiteral(" and tag guid ") << tagGuid
+        QNTRACE(QStringLiteral("Found tag local uid ") << tagLocalUid << QStringLiteral(" and tag guid ") << tagGuid
                 << QStringLiteral(" for note with local uid ") << noteLocalUid);
 
         int indexInNote = -1;
@@ -9161,13 +9161,13 @@ bool LocalStorageManagerPrivate::findAndSetResourcesPerNote(Note & note, ErrorSt
 
                 QString resourceLocalUid = value.toString();
                 resourceLocalUids << resourceLocalUid;
-                QNDEBUG(QStringLiteral("Found resource's local uid: ") << resourceLocalUid);
+                QNTRACE(QStringLiteral("Found resource's local uid: ") << resourceLocalUid);
             }
         }
     }
 
     int numResources = resourceLocalUids.size();
-    QNDEBUG(QStringLiteral("Found ") << numResources << QStringLiteral(" resources"));
+    QNTRACE(QStringLiteral("Found ") << numResources << QStringLiteral(" resources"));
 
     ErrorString error;
     QList<Resource> resources;
@@ -9191,7 +9191,7 @@ bool LocalStorageManagerPrivate::findAndSetResourcesPerNote(Note & note, ErrorSt
             return false;
         }
 
-        QNDEBUG(QStringLiteral("Found resource with local uid ") << resource.localUid()
+        QNTRACE(QStringLiteral("Found resource with local uid ") << resource.localUid()
                 << QStringLiteral(" for note with local uid ") << noteLocalUid);
     }
 

--- a/src/synchronization/RemoteToLocalSynchronizationManager.cpp
+++ b/src/synchronization/RemoteToLocalSynchronizationManager.cpp
@@ -845,8 +845,8 @@ void RemoteToLocalSynchronizationManager::onFindNoteCompleted(Note note, bool wi
     auto it = m_findNoteByGuidRequestIds.find(requestId);
     if (it != m_findNoteByGuidRequestIds.end())
     {
-        QNDEBUG(QStringLiteral("RemoteToLocalSynchronizationManager::onFindNoteCompleted: note = ")
-                << note << QStringLiteral(", requestId = ") << requestId);
+        QNDEBUG(QStringLiteral("RemoteToLocalSynchronizationManager::onFindNoteCompleted: requestId = ") << requestId);
+        QNTRACE(QStringLiteral("Note = ") << note);
 
         // NOTE: erase is required for proper work of the macro; the request would be re-inserted below if macro doesn't return from the method
         Q_UNUSED(m_findNoteByGuidRequestIds.erase(it));

--- a/src/types/Note.cpp
+++ b/src/types/Note.cpp
@@ -557,7 +557,7 @@ void Note::setResources(const QList<Resource> & resources)
             info.isDirty = it->isDirty();
             d->m_resourcesAdditionalInfo.push_back(info);
         }
-        QNDEBUG(QStringLiteral("Added ") << resources.size() << QStringLiteral(" resources to note"));
+        QNTRACE(QStringLiteral("Added ") << resources.size() << QStringLiteral(" resources to note"));
     }
     else
     {

--- a/src/utility/QuentierApplication.cpp
+++ b/src/utility/QuentierApplication.cpp
@@ -39,7 +39,7 @@ bool QuentierApplication::notify(QObject * pObject, QEvent * pEvent)
     catch(const std::exception & e)
     {
         SysInfo sysInfo;
-        QNERROR(QStringLiteral("Caught unhandled properly exception: ") << e.what()
+        QNERROR(QStringLiteral("Caught unhandled exception: ") << e.what()
                 << QStringLiteral(", backtrace: ") << sysInfo.stackTrace());
         return false;
     }

--- a/src/utility/ShortcutManager_p.cpp
+++ b/src/utility/ShortcutManager_p.cpp
@@ -243,7 +243,7 @@ void ShortcutManagerPrivate::setDefaultShortcut(int key, QKeySequence shortcut, 
 {
     QString keyString = keyToString(key);
 
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::setDefaultShortcut: key = ") << keyString << QStringLiteral(" (")
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::setDefaultShortcut: key = ") << keyString << QStringLiteral(" (")
             << key << QStringLiteral("), shortcut = ") << shortcut << QStringLiteral(", context = ") << context
             << QStringLiteral(", account: ") << account);
 


### PR DESCRIPTION
As I wrote in https://github.com/d1vanov/quentier/issues/206
Currently the logging produces extremely much data for both DEBUG and TRACE. For few minutes there a tens of megabytes. This makes the log very difficult to use, unless you already know for what message you are looking.

The idea is: some DEBUGs should become INFO.
Some other very common/verbose DEBUGs should become TRACE.
DEBUG level should not log note contents (this may be blocker for user reporting bugs, as e.g. I don't want to post log with lot of my real notes publicly to github).

Here are few proposed changes to check, if its even acceptable to you... 