### PR TITLE
Improvements in log verbosity

### DIFF
--- a/headers/quentier/logging/QuentierLogger.h
+++ b/headers/quentier/logging/QuentierLogger.h
@@ -99,4 +99,6 @@ void QUENTIER_EXPORT QuentierRestartLogging();
 #define QUENTIER_ADD_STDOUT_LOG_DESTINATION() \
     quentier::QuentierAddStdOutLogDestination()
 
+#define QNLOG_FILE_LINENUMBER_DELIMITER ":"
+
 #endif // LIB_QUENTIER_LOGGING_QUENTIER_LOGGER_H

--- a/src/local_storage/LocalStorageCacheManager_p.cpp
+++ b/src/local_storage/LocalStorageCacheManager_p.cpp
@@ -88,8 +88,7 @@ void LocalStorageCacheManagerPrivate::cache##Type(const Type & name) \
             res = m_cacheExpiryChecker->expiry_checker(); \
             if (Q_UNLIKELY(!res)) { \
                 auto latIndexBegin = latIndex.begin(); \
-                QNDEBUG(QStringLiteral("Going to remove the object from local storage cache")); \
-                QNTRACE(QStringLiteral("Content: ") << *latIndexBegin); \
+                QNTRACE(QStringLiteral("Going to remove the object from local storage cache") << *latIndexBegin); \
                 Q_UNUSED(latIndex.erase(latIndexBegin)); \
                 continue; \
             } \
@@ -106,7 +105,7 @@ void LocalStorageCacheManagerPrivate::cache##Type(const Type & name) \
     Index::iterator it = uniqueIndex.find(name.IndexAccessor()); \
     if (it != uniqueIndex.end()) { \
         uniqueIndex.replace(it, name##Holder); \
-        QNDEBUG(QStringLiteral("Updated " #name " in the local storage cache: ") << name); \
+        QNTRACE(QStringLiteral("Updated " #name " in the local storage cache: ") << name); \
         return; \
     } \
     \
@@ -119,8 +118,7 @@ void LocalStorageCacheManagerPrivate::cache##Type(const Type & name) \
         throw LocalStorageCacheManagerException(error); \
     } \
     \
-    QNDEBUG(QStringLiteral("Added " #name " to the local storage cache")); \
-    QNTRACE(QStringLiteral("Content: ") << name); \
+    QNTRACE(QStringLiteral("Added " #name " to the local storage cache") << name); \
 }
 
 CACHE_OBJECT(Note, note, NotesCache, m_notesCache, checkNotes, ByLocalUid, localUid)

--- a/src/local_storage/LocalStorageManager_p.cpp
+++ b/src/local_storage/LocalStorageManager_p.cpp
@@ -389,10 +389,11 @@ int LocalStorageManagerPrivate::notebookCount(ErrorString & errorDescription) co
 void LocalStorageManagerPrivate::switchUser(const Account & account,
                                             const bool startFromScratch, const bool overrideLock)
 {
-    QNDEBUG(QStringLiteral("LocalStorageManagerPrivate::switchUser: start from scratch = ")
+    QNDEBUG(QStringLiteral("LocalStorageManagerPrivate::switchUser: ") << account.name()
+            << QStringLiteral(", start from scratch = ")
             << (startFromScratch ? QStringLiteral("true") : QStringLiteral("false"))
-            << QStringLiteral(", override lock = ") << (overrideLock ? QStringLiteral("true") : QStringLiteral("false"))
-            << QStringLiteral(", account: ") << account);
+            << QStringLiteral(", override lock = ") << (overrideLock ? QStringLiteral("true") : QStringLiteral("false")));
+    QNTRACE(QStringLiteral("Account: ") << account);
 
     if (!m_databaseFilePath.isEmpty() &&
         (m_currentAccount.type() == account.type()) &&

--- a/src/logging/QuentierLogger.cpp
+++ b/src/logging/QuentierLogger.cpp
@@ -27,7 +27,7 @@ void QuentierAddLogEntry(const QString & sourceFileName, const int sourceFileLin
     }
 
     QString logEntry = relativeSourceFileName;
-    logEntry += QStringLiteral(" @ ");
+    logEntry += QStringLiteral(QNLOG_FILE_LINENUMBER_DELIMITER);
     logEntry += QString::number(sourceFileLineNumber);
     logEntry += QStringLiteral(" [");
 

--- a/src/note_editor/NoteEditor_p.cpp
+++ b/src/note_editor/NoteEditor_p.cpp
@@ -1706,7 +1706,7 @@ void NoteEditorPrivate::onRemoveResourceUndoRedoFinished(const QVariant & data, 
 void NoteEditorPrivate::onRenameResourceDelegateFinished(QString oldResourceName, QString newResourceName,
                                                          Resource resource, bool performingUndo)
 {
-    QNDEBUG(QStringLiteral("NoteEditorPrivate::onRenameResourceDelegateFinished: old resource name = ") << oldResourceName
+    QNTRACE(QStringLiteral("NoteEditorPrivate::onRenameResourceDelegateFinished: old resource name = ") << oldResourceName
             << QStringLiteral(", new resource name = ") << newResourceName << QStringLiteral(", performing undo = ")
             << (performingUndo ? QStringLiteral("true") : QStringLiteral("false")) << QStringLiteral(", resource: ") << resource);
 
@@ -3322,7 +3322,7 @@ void NoteEditorPrivate::saveNoteResourcesToLocalFiles()
 
 bool NoteEditorPrivate::saveResourceToLocalFile(const Resource & resource)
 {
-    QNDEBUG(QStringLiteral("NoteEditorPrivate::saveResourceToLocalFile: ") << resource);
+    QNTRACE(QStringLiteral("NoteEditorPrivate::saveResourceToLocalFile: ") << resource);
 
     if (Q_UNLIKELY(!resource.hasMime())) {
         ErrorString error(QT_TR_NOOP("Can't save the resource to local file: no resource mime type"));

--- a/src/note_editor/NoteEditor_p.cpp
+++ b/src/note_editor/NoteEditor_p.cpp
@@ -5344,7 +5344,7 @@ void NoteEditorPrivate::initialize(FileIOProcessorAsync & fileIOProcessorAsync,
 
 void NoteEditorPrivate::setAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("NoteEditorPrivate::setAccount: ") << account);
+    QNDEBUG(QStringLiteral("NoteEditorPrivate::setAccount: ") << account.name());
 
     if (!m_pAccount.isNull() && (m_pAccount->type() == account.type()) &&
         (m_pAccount->name() == account.name()) && (m_pAccount->id() == account.id()))

--- a/src/synchronization/RemoteToLocalSynchronizationManager.cpp
+++ b/src/synchronization/RemoteToLocalSynchronizationManager.cpp
@@ -251,7 +251,7 @@ bool RemoteToLocalSynchronizationManager::active() const
 
 void RemoteToLocalSynchronizationManager::setAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("RemoteToLocalSynchronizationManager::setAccount: ") << account);
+    QNDEBUG(QStringLiteral("RemoteToLocalSynchronizationManager::setAccount: ") << account.name());
 
     if (m_user.hasId() && (m_user.id() != account.id())) {
         QNDEBUG(QStringLiteral("Switching to a different user, clearing the current state"));

--- a/src/types/Note.cpp
+++ b/src/types/Note.cpp
@@ -413,7 +413,7 @@ void Note::setTagGuids(const QStringList & guids)
         tagGuids << *it;
     }
 
-    QNDEBUG(QStringLiteral("Added ") << numTagGuids << QStringLiteral(" tag guids to note"));
+    QNTRACE(QStringLiteral("Added ") << numTagGuids << QStringLiteral(" tag guids to note"));
 }
 
 void Note::addTagGuid(const QString & guid)

--- a/src/utility/ShortcutManager_p.cpp
+++ b/src/utility/ShortcutManager_p.cpp
@@ -39,22 +39,22 @@ ShortcutManagerPrivate::ShortcutManagerPrivate(ShortcutManager & shortcutManager
 
 QKeySequence ShortcutManagerPrivate::shortcut(const int key, const Account & account, const QString & context) const
 {
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::shortcut: key = ") << key << QStringLiteral(", context = ")
-            << context << QStringLiteral(", account: ") << account);
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::shortcut: key = ") << key << QStringLiteral(", context = ")
+            << context << QStringLiteral(", account: ") << account.name());
 
     QKeySequence userKeySequence = userShortcut(key, account, context);
     if (!userKeySequence.isEmpty()) {
         return userKeySequence;
     }
 
-    QNDEBUG(QStringLiteral("User shortcut is empty, fallback to the default shortcut"));
+    QNTRACE(QStringLiteral("User shortcut is empty, fallback to the default shortcut"));
     return defaultShortcut(key, account, context);
 }
 
 QKeySequence ShortcutManagerPrivate::shortcut(const QString & nonStandardKey, const Account & account, const QString & context) const
 {
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::shortcut: non-standard key = ") << nonStandardKey
-            << QStringLiteral(", context = ") << context << QStringLiteral(", account: ") << account);
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::shortcut: non-standard key = ") << nonStandardKey
+            << QStringLiteral(", context = ") << context << QStringLiteral(", account: ") << account.name());
 
     QKeySequence userKeySequence = userShortcut(nonStandardKey, account, context);
     if (!userKeySequence.isEmpty()) {
@@ -69,8 +69,8 @@ QKeySequence ShortcutManagerPrivate::defaultShortcut(const int key, const Accoun
 {
     QString keyString = keyToString(key);
 
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::defaultShortcut: key = ") << keyString << QStringLiteral(" (")
-            << key << QStringLiteral("), context = ") << context << QStringLiteral(", account: ") << account);
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::defaultShortcut: key = ") << keyString << QStringLiteral(" (")
+            << key << QStringLiteral("), context = ") << context << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(keyString.isEmpty())) {
         return QKeySequence();
@@ -108,8 +108,8 @@ QKeySequence ShortcutManagerPrivate::defaultShortcut(const int key, const Accoun
 QKeySequence ShortcutManagerPrivate::defaultShortcut(const QString & nonStandardKey, const Account & account,
                                                      const QString & context) const
 {
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::defaultShortcut: non-standard key = ") << nonStandardKey
-            << QStringLiteral(", context = ") << context << QStringLiteral(", account: ") << account);
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::defaultShortcut: non-standard key = ") << nonStandardKey
+            << QStringLiteral(", context = ") << context << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(nonStandardKey.isEmpty())) {
         return QKeySequence();
@@ -138,8 +138,8 @@ QKeySequence ShortcutManagerPrivate::userShortcut(const int key, const Account &
 {
     QString keyString = keyToString(key);
 
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::userShortcut: key = ") << keyString << QStringLiteral(" (")
-            << key << QStringLiteral("), context = ") << context << QStringLiteral(", account: ") << account);
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::userShortcut: key = ") << keyString << QStringLiteral(" (")
+            << key << QStringLiteral("), context = ") << context << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(keyString.isEmpty())) {
         return QKeySequence();
@@ -166,8 +166,8 @@ QKeySequence ShortcutManagerPrivate::userShortcut(const int key, const Account &
 
 QKeySequence ShortcutManagerPrivate::userShortcut(const QString & nonStandardKey, const Account & account, const QString & context) const
 {
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::userShortcut: non-standard key = ") << nonStandardKey
-            << QStringLiteral(", context = ") << context << QStringLiteral(", account: ") << account);
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::userShortcut: non-standard key = ") << nonStandardKey
+            << QStringLiteral(", context = ") << context << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(nonStandardKey.isEmpty())) {
         return QKeySequence();
@@ -194,9 +194,9 @@ void ShortcutManagerPrivate::setUserShortcut(int key, QKeySequence shortcut, con
 {
     QString keyString = keyToString(key);
 
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::setUserShortcut: key = ") << keyString << QStringLiteral(" (")
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::setUserShortcut: key = ") << keyString << QStringLiteral(" (")
             << key << QStringLiteral("), shortcut = ") << shortcut << QStringLiteral(", context = ") << context
-            << QStringLiteral(", account: ") << account);
+            << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(keyString.isEmpty())) {
         return;
@@ -218,9 +218,9 @@ void ShortcutManagerPrivate::setUserShortcut(int key, QKeySequence shortcut, con
 void ShortcutManagerPrivate::setNonStandardUserShortcut(QString nonStandardKey, QKeySequence shortcut,
                                                         const Account & account, QString context)
 {
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::setNonStandardUserShortcut: non-standard key = ") << nonStandardKey
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::setNonStandardUserShortcut: non-standard key = ") << nonStandardKey
             << QStringLiteral(", shortcut = ") << shortcut << QStringLiteral(", context = ") << context
-            << QStringLiteral(", account: ") << account);
+            << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(nonStandardKey.isEmpty())) {
         return;
@@ -245,7 +245,7 @@ void ShortcutManagerPrivate::setDefaultShortcut(int key, QKeySequence shortcut, 
 
     QNTRACE(QStringLiteral("ShortcutManagerPrivate::setDefaultShortcut: key = ") << keyString << QStringLiteral(" (")
             << key << QStringLiteral("), shortcut = ") << shortcut << QStringLiteral(", context = ") << context
-            << QStringLiteral(", account: ") << account);
+            << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(keyString.isEmpty())) {
         return;
@@ -275,9 +275,9 @@ void ShortcutManagerPrivate::setDefaultShortcut(int key, QKeySequence shortcut, 
 void ShortcutManagerPrivate::setNonStandardDefaultShortcut(QString nonStandardKey, QKeySequence shortcut,
                                                            const Account & account, QString context)
 {
-    QNDEBUG(QStringLiteral("ShortcutManagerPrivate::setNonStandardDefaultShortcut: non-standard key = ") << nonStandardKey
+    QNTRACE(QStringLiteral("ShortcutManagerPrivate::setNonStandardDefaultShortcut: non-standard key = ") << nonStandardKey
             << QStringLiteral(", shortcut = ") << shortcut << QStringLiteral(", context = ") << context
-            << QStringLiteral(", account: ") << account);
+            << QStringLiteral(", account: ") << account.name());
 
     if (Q_UNLIKELY(nonStandardKey.isEmpty())) {
         return;


### PR DESCRIPTION
This is next iteration at log verbosity adjustment - https://github.com/d1vanov/quentier/issues/196
It changes the delimiter for sourcefile:line from " @ " to ":" (there for it should be merged together with similar PR on quentier repository).
At selected places log level is changed from DEBUG to TRACE.
The idea is to make DEBUG level more usable - still very verbose - but manageable.
Although I taken care, it can happen that as some place I reduced to much - but I will readjust in next iterations. Normally I would do one PR for feature, but here I suggest more iterations.

At few places I reduced "account" to "account.name()" which seems reasonable.