### PR TITLE
Create note editor page only once

### DIFF
--- a/src/note_editor/NoteEditor_p.cpp
+++ b/src/note_editor/NoteEditor_p.cpp
@@ -6595,6 +6595,10 @@ void NoteEditorPrivate::setupNoteEditorPage()
 {
     QNDEBUG("note_editor", "NoteEditorPrivate::setupNoteEditorPage");
 
+    if (page()) {
+        return;
+    }
+
     NoteEditorPage * page = new NoteEditorPage(*this);
 
     page->settings()->setAttribute(


### PR DESCRIPTION
It appears to prevent crashes somewhere deep in QtWebEngine guts with some versions of QtWebEngine (but not others).
So, it is a sort of a workaround for what appears to be a Qt bug